### PR TITLE
Fix compilation files not included in conf object when `obj.source` undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ Plugin.prototype.apply = function (compiler) {
             }
           });
         });
-        merge(obj.source, { include: files });
+        obj.source = merge(obj.source, { include: files });
       }
 
       /**


### PR DESCRIPTION
# Bug 
When configuration `obj.source` doesn't exists (`undefined`), `merge` would be failed. Because it calls `merge(undefined, { includes: [ ... ] })` with no reference to `obj.source`.

## Reproduction
Remove `obj.source` from JsDoc configuration and compile.